### PR TITLE
Fix velocity unit

### DIFF
--- a/src/ASEconvert.jl
+++ b/src/ASEconvert.jl
@@ -25,6 +25,9 @@ function __init__()
 end
 
 function ase_to_system(S::Type{<:AbstractSystem}, ase_atoms::Py)
+    # For ASE units, see https://wiki.fysik.dtu.dk/ase/ase/units.html
+    # In particular note that uTime = u"Å" * sqrt(u"u" / u"eV") and thus
+    # uVelocity = sqrt(u"u" / u"eV")
     box = [pyconvert(Vector, ase_atoms.cell[i])u"Å" for i = 0:2]
 
     atnums     = pyconvert(Vector, ase_atoms.get_atomic_numbers())
@@ -37,7 +40,7 @@ function ase_to_system(S::Type{<:AbstractSystem}, ase_atoms::Py)
     ase_info   = pyconvert(Dict{String,Any}, ase_atoms.info)
 
     atoms = map(1:length(atnums)) do i
-        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :]u"eV^0.5/u^0.5";
+        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :]*sqrt(u"eV"/u"u");
                        atomic_symbol=Symbol(atsyms[i]),
                        atomic_number=atnums[i],
                        atomic_mass=atmasses[i]u"u",

--- a/src/ASEconvert.jl
+++ b/src/ASEconvert.jl
@@ -24,10 +24,12 @@ function __init__()
     end
 end
 
+# For ASE units, see https://wiki.fysik.dtu.dk/ase/ase/units.html
+# In particular note that uTime = u"Å" * sqrt(u"u" / u"eV") and thus
+const uVelocity = sqrt(u"eV" / u"u")
+
+
 function ase_to_system(S::Type{<:AbstractSystem}, ase_atoms::Py)
-    # For ASE units, see https://wiki.fysik.dtu.dk/ase/ase/units.html
-    # In particular note that uTime = u"Å" * sqrt(u"u" / u"eV") and thus
-    # uVelocity = sqrt(u"u" / u"eV")
     box = [pyconvert(Vector, ase_atoms.cell[i])u"Å" for i = 0:2]
 
     atnums     = pyconvert(Vector, ase_atoms.get_atomic_numbers())
@@ -40,7 +42,7 @@ function ase_to_system(S::Type{<:AbstractSystem}, ase_atoms::Py)
     ase_info   = pyconvert(Dict{String,Any}, ase_atoms.info)
 
     atoms = map(1:length(atnums)) do i
-        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :]*sqrt(u"eV"/u"u");
+        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :] * uVelocity;
                        atomic_symbol=Symbol(atsyms[i]),
                        atomic_number=atnums[i],
                        atomic_mass=atmasses[i]u"u",
@@ -100,7 +102,7 @@ function convert_ase(system::AbstractSystem{D}) where {D}
     if !ismissing(velocity(system))
         velocities = zeros(n_atoms, 3)
         for at = 1:n_atoms
-            velocities[at, 1:D] = ustrip.(u"eV^0.5/u^0.5", velocity(system, at))
+            velocities[at, 1:D] = ustrip.(uVelocity, velocity(system, at))
         end
     end
 

--- a/src/ASEconvert.jl
+++ b/src/ASEconvert.jl
@@ -37,7 +37,7 @@ function ase_to_system(S::Type{<:AbstractSystem}, ase_atoms::Py)
     ase_info   = pyconvert(Dict{String,Any}, ase_atoms.info)
 
     atoms = map(1:length(atnums)) do i
-        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :]u"Å/s";
+        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :]u"eV^0.5/u^0.5";
                        atomic_symbol=Symbol(atsyms[i]),
                        atomic_number=atnums[i],
                        atomic_mass=atmasses[i]u"u",
@@ -97,7 +97,7 @@ function convert_ase(system::AbstractSystem{D}) where {D}
     if !ismissing(velocity(system))
         velocities = zeros(n_atoms, 3)
         for at = 1:n_atoms
-            velocities[at, 1:D] = ustrip.(u"Å/s", velocity(system, at))
+            velocities[at, 1:D] = ustrip.(u"eV^0.5/u^0.5", velocity(system, at))
         end
     end
 

--- a/test/common.jl
+++ b/test/common.jl
@@ -18,7 +18,7 @@ function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
     if !(:velocity in ignore_atprop)
         @test ismissing(velocity(s)) == ismissing(velocity(t))
         if !ismissing(velocity(s)) && !ismissing(velocity(t))
-            @test maximum(norm, velocity(s) - velocity(t)) < atol * u"eV^0.5/u^0.5"
+            @test maximum(norm, velocity(s) - velocity(t)) < atol * u"Å/s"
         end
     end
 
@@ -67,7 +67,7 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
     # Generate some random data to store in Atoms
     atprop = Dict{Symbol,Any}(
         :position        => [randn(3) for _ = 1:n_atoms]u"Å",
-        :velocity        => [randn(3) for _ = 1:n_atoms]u"eV^0.5/u^0.5",
+        :velocity        => [randn(3) for _ = 1:n_atoms]u"Å/s",
         :atomic_symbol   => [:H, :H, :C, :N, :He],
         :atomic_number   => [1, 1, 6, 7, 2],
         :charge          => [2, 1, 3.0, -1.0, 0.0]u"e_au",

--- a/test/common.jl
+++ b/test/common.jl
@@ -18,7 +18,7 @@ function test_approx_eq(s::AbstractSystem, t::AbstractSystem;
     if !(:velocity in ignore_atprop)
         @test ismissing(velocity(s)) == ismissing(velocity(t))
         if !ismissing(velocity(s)) && !ismissing(velocity(t))
-            @test maximum(norm, velocity(s) - velocity(t)) < atol * u"Å/s"
+            @test maximum(norm, velocity(s) - velocity(t)) < atol * u"eV^0.5/u^0.5"
         end
     end
 
@@ -67,7 +67,7 @@ function make_test_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[],
     # Generate some random data to store in Atoms
     atprop = Dict{Symbol,Any}(
         :position        => [randn(3) for _ = 1:n_atoms]u"Å",
-        :velocity        => [randn(3) for _ = 1:n_atoms]u"Å/s",
+        :velocity        => [randn(3) for _ = 1:n_atoms]u"eV^0.5/u^0.5",
         :atomic_symbol   => [:H, :H, :C, :N, :He],
         :atomic_number   => [1, 1, 6, 7, 2],
         :charge          => [2, 1, 3.0, -1.0, 0.0]u"e_au",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ include("common.jl")
             @test(pyconvert(Vector, atom.position)
                   ≈ ustrip.(u"Å", atprop.position[i]), atol=1e-14)
             @test(pyconvert(Vector, ase_atoms.get_velocities()[i - 1])
-                  ≈ ustrip.(u"Å/s", atprop.velocity[i]), atol=1e-14)
+                  ≈ ustrip.(u"eV^0.5/u^0.5", atprop.velocity[i]), atol=1e-14)
 
             @test pyconvert(String,  atom.symbol) == string(atprop.atomic_symbol[i])
             @test pyconvert(Int,     atom.number) == atprop.atomic_number[i]
@@ -88,7 +88,7 @@ include("common.jl")
         @test bounding_box(bulk_Fe) == a .* [[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]]
         @test atomic_symbol(bulk_Fe) == [:Fe, :Fe]
         @test position(bulk_Fe) == [[0.0, 0.0, 0.0], [1.435, 1.435, 1.435]]u"Å"
-        @test velocity(bulk_Fe) == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]u"Å/s"
+        @test velocity(bulk_Fe) == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]u"eV^0.5/u^0.5"
     end
 
     @testset "Writing / reading files using ASE" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ include("common.jl")
             @test(pyconvert(Vector, atom.position)
                   ≈ ustrip.(u"Å", atprop.position[i]), atol=1e-14)
             @test(pyconvert(Vector, ase_atoms.get_velocities()[i - 1])
-                  ≈ ustrip.(u"eV^0.5/u^0.5", atprop.velocity[i]), atol=1e-14)
+                  ≈ ustrip.(sqrt(u"eV"/u"u"), atprop.velocity[i]), atol=1e-12)
 
             @test pyconvert(String,  atom.symbol) == string(atprop.atomic_symbol[i])
             @test pyconvert(Int,     atom.number) == atprop.atomic_number[i]
@@ -88,7 +88,7 @@ include("common.jl")
         @test bounding_box(bulk_Fe) == a .* [[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]]
         @test atomic_symbol(bulk_Fe) == [:Fe, :Fe]
         @test position(bulk_Fe) == [[0.0, 0.0, 0.0], [1.435, 1.435, 1.435]]u"Å"
-        @test velocity(bulk_Fe) == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]u"eV^0.5/u^0.5"
+        @test velocity(bulk_Fe) == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]*sqrt(u"eV"/u"u")
     end
 
     @testset "Writing / reading files using ASE" begin
@@ -97,7 +97,7 @@ include("common.jl")
             file = joinpath(d, "output.xyz")
             ase.io.write(file, convert_ase(system))
             newsystem = pyconvert(FlexibleSystem, ase.io.read(file))
-            test_approx_eq(system, newsystem; atol=1e-6)
+            test_approx_eq(system, newsystem; rtol=1e-6)
         end
     end
 
@@ -121,7 +121,7 @@ include("common.jl")
             newsystem = ExtXYZ.Atoms(ExtXYZ.read_frame(file))
             # TODO The ignore_atprop is needed because of missing features in AtomsBase.
             test_approx_eq(system, newsystem;
-                           atol=1e-6, ignore_atprop=[:magnetic_moment, :charge, :velocity])
+                           rtol=1e-6, ignore_atprop=[:magnetic_moment, :charge, :velocity])
         end
     end
 end


### PR DESCRIPTION
As a response to this https://github.com/JuliaMolSim/JuLIP.jl/pull/160#issuecomment-1410403009

ASE units defined in [here](https://wiki.fysik.dtu.dk/ase/ase/units.html) state that _"Electron volts (eV), Ångström (Ang), the atomic mass unit and Kelvin are defined as 1.0."_

Energy has dimensions of "M*L^2/T^2" or mass times velocity squared. From this you can deduce that square root of energy divided by square root of mass gives the unit of velocity, or using Unitful terms `u"eV^0.5/u^0.5"`.

I am not completely sure that this is the correct velocity unit... But this is how I understood it.