### PR TITLE
AtomsCalculator interface for ASE calculators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.5"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
+AtomsCalculators = "a3e0e189-c65a-42c1-833c-339540406eb1"
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
@@ -14,6 +15,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 [compat]
 AtomsBaseTesting = "0.1"
 AtomsBase = "0.3"
+AtomsCalculators = "0.1.1"
 CondaPkg = "0.2"
 PeriodicTable = "1"
 PythonCall = "0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ASEconvert"
 uuid = "3da9722f-58c2-4165-81be-b4d7253e8fd2"
 authors = ["Michael F. Herbst <info@michael-herbst.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/README.md
+++ b/README.md
@@ -27,3 +27,24 @@ atoms_ab = pyconvert(AbstractSystem, atoms_ase)
 newatoms_ase = convert_ase(atoms_ab)
 newatoms_ase.pop(4)
 ```
+
+### AtomsCalculators interface
+
+You can use ASE calculators in julia, by wrapping them to a `ASEcalculator` structure. Here is a brief example
+
+
+```julia
+using AtomsCalculators
+using ASEconvert
+using PythonCall
+
+fname = "path to eam potential file"
+EAM = pyimport("ase.calculators.eam")
+eam_cal = ASEcalculator(EAM.EAM(potential=fname))
+
+atoms_ase = ase.build.bulk("Ni") * pytuple((4, 3, 2))
+atoms_ab = pyconvert(AbstractSystem, atoms_ase)
+
+AtomsCalculators.potential_energy(atoms_ab, eam_cal)
+AtomsCalculators.forces(atoms_ab, eam_cal)
+```

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ using AtomsCalculators
 using ASEconvert
 using PythonCall
 
-fname = "path to eam potential file"
+potential = "path to eam potential file"
 EAM = pyimport("ase.calculators.eam")
-eam_cal = ASEcalculator(EAM.EAM(potential=fname))
+eam_cal = ASEcalculator(EAM.EAM(;potential=potential))
 
 atoms_ase = ase.build.bulk("Ni") * pytuple((4, 3, 2))
 atoms_ab = pyconvert(AbstractSystem, atoms_ase)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ using PythonCall
 
 potential = "path to eam potential file"
 EAM = pyimport("ase.calculators.eam")
-eam_cal = ASEcalculator(EAM.EAM(;potential=potential))
+eam_cal = ASEcalculator(EAM.EAM(potential))
 
 atoms_ase = ase.build.bulk("Ni") * pytuple((4, 3, 2))
 atoms_ab = pyconvert(AbstractSystem, atoms_ase)

--- a/src/ASEconvert.jl
+++ b/src/ASEconvert.jl
@@ -3,9 +3,7 @@ using PythonCall
 using AtomsBase
 using Unitful
 using UnitfulAtomic
-import PeriodicTable
 
-export convert_ase
 export ase
 export pyconvert, pytuple  # Reexport from PythonCall
 export AbstractSystem      # Reexport from AtomsBase
@@ -24,129 +22,8 @@ function __init__()
     end
 end
 
-# For ASE units, see https://wiki.fysik.dtu.dk/ase/ase/units.html
-# In particular note that uTime = u"Å" * sqrt(u"u" / u"eV") and thus
-const uVelocity = sqrt(u"eV" / u"u")
 
-
-function ase_to_system(S::Type{<:AbstractSystem}, ase_atoms::Py)
-    box = [pyconvert(Vector, ase_atoms.cell[i])u"Å" for i = 0:2]
-
-    atnums     = pyconvert(Vector, ase_atoms.get_atomic_numbers())
-    atsyms     = pyconvert(Vector, ase_atoms.symbols)
-    atmasses   = pyconvert(Vector, ase_atoms.get_masses())
-    positions  = pyconvert(Matrix, ase_atoms.get_positions())
-    velocities = pyconvert(Matrix, ase_atoms.get_velocities())
-    magmoms    = pyconvert(Vector, ase_atoms.get_initial_magnetic_moments())
-    charges    = pyconvert(Vector, ase_atoms.get_initial_charges())
-    ase_info   = pyconvert(Dict{String,Any}, ase_atoms.info)
-
-    atoms = map(1:length(atnums)) do i
-        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :] * uVelocity;
-                       atomic_symbol=Symbol(atsyms[i]),
-                       atomic_number=atnums[i],
-                       atomic_mass=atmasses[i]u"u",
-                       magnetic_moment=magmoms[i],
-                       charge=charges[i]u"e_au")
-    end
-
-    # Parse extra data in info struct
-    info = Dict{Symbol, Any}()
-    for (k, v) in ase_info
-        if k == "charge"
-            info[Symbol(k)] = v * u"e_au"
-        else
-            info[Symbol(k)] = v
-        end
-    end
-
-    bcs = [p ? Periodic() : DirichletZero() for p in pyconvert(Vector, ase_atoms.pbc)]
-    PythonCall.pyconvert_return(atomic_system(atoms, box, bcs; info...))
-end
-
-"""
-    convert_ase(system::AbstractSystem)
-
-Convert a passed `system` (which satisfies the AtomsBase.AbstractSystem interface) to an
-`ase.Atoms` datastructure. Conversions to other ASE objects from equivalent Julia objects
-may be added as additional methods in the future.
-"""
-function convert_ase(system::AbstractSystem{D}) where {D}
-    D != 3 && @warn "1D and 2D systems not yet fully supported."
-
-    n_atoms = length(system)
-    pbc     = map(isequal(Periodic()), boundary_conditions(system))
-    numbers = atomic_number(system)
-    masses  = ustrip.(u"u", atomic_mass(system))
-
-    symbols_match = [
-        PeriodicTable.elements[atnum].symbol == string(atomic_symbol(system, i))
-        for (i, atnum) in enumerate(numbers)
-    ]
-    if !all(symbols_match)
-        @warn("Mismatch between atomic numbers and atomic symbols, which is not " *
-              "supported in ASE. Atomic numbers take preference.")
-    end
-
-    cell = zeros(3, 3)
-    for (i, v) in enumerate(bounding_box(system))
-        cell[i, 1:D] = ustrip.(u"Å", v)
-    end
-
-    positions = zeros(n_atoms, 3)
-    for at = 1:n_atoms
-        positions[at, 1:D] = ustrip.(u"Å", position(system, at))
-    end
-
-    velocities = nothing
-    if !ismissing(velocity(system))
-        velocities = zeros(n_atoms, 3)
-        for at = 1:n_atoms
-            velocities[at, 1:D] = ustrip.(uVelocity, velocity(system, at))
-        end
-    end
-
-    # We don't map any extra atom properties, which are not available in ASE as this
-    # only causes a mess: ASE could do something to the atoms, but not taking
-    # care of the extra properties, thus rendering the extra properties invalid
-    # without the user noticing.
-    charges = nothing
-    magmoms = nothing
-    for key in atomkeys(system)
-        if key in (:position, :velocity, :atomic_symbol, :atomic_number, :atomic_mass)
-            continue  # Already dealt with
-        elseif key == :charge
-            charges = ustrip.(u"e_au", system[:, :charge])
-        elseif key == :magnetic_moment
-            magmoms = system[:, :magnetic_moment]
-        else
-            @warn "Skipping atomic property $key, which is not supported in ASE."
-        end
-    end
-
-    # Map extra system properties
-    info = Dict{String, Any}()
-    for (k, v) in pairs(system)
-        if k in (:bounding_box, :boundary_conditions)
-            continue
-        elseif k in (:charge, )
-            info[string(k)] = ustrip(u"e_au", v)
-        elseif v isa Quantity || (v isa AbstractArray && eltype(v) <: Quantity)
-            @warn("Unitful quantities are not yet supported in convert_ase. " *
-                  "Ignoring key $k")
-        else
-            info[string(k)] = v
-        end
-    end
-
-    ase.Atoms(; positions, numbers, masses, magmoms, charges,
-              cell, pbc, velocities, info)
-end
-
-# TODO Could have a convert_ase(Vector{AbstractSystem}) to make an ASE trajectory
-# TODO Could have a convert_ase(Vector{Vector{Unitful}}) to make an ASE cell
-# TODO Could have a way to make an ASE calculator from an InteratomicPotential object
-
+include("ase_conversions.jl")
 include("atoms_calculators.jl")
 
 

--- a/src/ASEconvert.jl
+++ b/src/ASEconvert.jl
@@ -147,4 +147,7 @@ end
 # TODO Could have a convert_ase(Vector{Vector{Unitful}}) to make an ASE cell
 # TODO Could have a way to make an ASE calculator from an InteratomicPotential object
 
+include("atoms_calculators.jl")
+
+
 end

--- a/src/ASEconvert.jl
+++ b/src/ASEconvert.jl
@@ -8,6 +8,9 @@ export ase
 export pyconvert, pytuple  # Reexport from PythonCall
 export AbstractSystem      # Reexport from AtomsBase
 
+export ASEcalculator
+export convert_ase
+
 """
 Global constant representing the `ase` python module available from Julia.
 """

--- a/src/ase_conversions.jl
+++ b/src/ase_conversions.jl
@@ -1,0 +1,127 @@
+import PeriodicTable
+
+export convert_ase
+
+
+# For ASE units, see https://wiki.fysik.dtu.dk/ase/ase/units.html
+# In particular note that uTime = u"Å" * sqrt(u"u" / u"eV") and thus
+const uVelocity = sqrt(u"eV" / u"u")
+
+
+function ase_to_system(S::Type{<:AbstractSystem}, ase_atoms::Py)
+    box = [pyconvert(Vector, ase_atoms.cell[i])u"Å" for i = 0:2]
+
+    atnums     = pyconvert(Vector, ase_atoms.get_atomic_numbers())
+    atsyms     = pyconvert(Vector, ase_atoms.symbols)
+    atmasses   = pyconvert(Vector, ase_atoms.get_masses())
+    positions  = pyconvert(Matrix, ase_atoms.get_positions())
+    velocities = pyconvert(Matrix, ase_atoms.get_velocities())
+    magmoms    = pyconvert(Vector, ase_atoms.get_initial_magnetic_moments())
+    charges    = pyconvert(Vector, ase_atoms.get_initial_charges())
+    ase_info   = pyconvert(Dict{String,Any}, ase_atoms.info)
+
+    atoms = map(1:length(atnums)) do i
+        AtomsBase.Atom(atnums[i], positions[i, :]u"Å", velocities[i, :] * uVelocity;
+                       atomic_symbol=Symbol(atsyms[i]),
+                       atomic_number=atnums[i],
+                       atomic_mass=atmasses[i]u"u",
+                       magnetic_moment=magmoms[i],
+                       charge=charges[i]u"e_au")
+    end
+
+    # Parse extra data in info struct
+    info = Dict{Symbol, Any}()
+    for (k, v) in ase_info
+        if k == "charge"
+            info[Symbol(k)] = v * u"e_au"
+        else
+            info[Symbol(k)] = v
+        end
+    end
+
+    bcs = [p ? Periodic() : DirichletZero() for p in pyconvert(Vector, ase_atoms.pbc)]
+    PythonCall.pyconvert_return(atomic_system(atoms, box, bcs; info...))
+end
+
+"""
+    convert_ase(system::AbstractSystem)
+
+Convert a passed `system` (which satisfies the AtomsBase.AbstractSystem interface) to an
+`ase.Atoms` datastructure. Conversions to other ASE objects from equivalent Julia objects
+may be added as additional methods in the future.
+"""
+function convert_ase(system::AbstractSystem{D}) where {D}
+    D != 3 && @warn "1D and 2D systems not yet fully supported."
+
+    n_atoms = length(system)
+    pbc     = map(isequal(Periodic()), boundary_conditions(system))
+    numbers = atomic_number(system)
+    masses  = ustrip.(u"u", atomic_mass(system))
+
+    symbols_match = [
+        PeriodicTable.elements[atnum].symbol == string(atomic_symbol(system, i))
+        for (i, atnum) in enumerate(numbers)
+    ]
+    if !all(symbols_match)
+        @warn("Mismatch between atomic numbers and atomic symbols, which is not " *
+              "supported in ASE. Atomic numbers take preference.")
+    end
+
+    cell = zeros(3, 3)
+    for (i, v) in enumerate(bounding_box(system))
+        cell[i, 1:D] = ustrip.(u"Å", v)
+    end
+
+    positions = zeros(n_atoms, 3)
+    for at = 1:n_atoms
+        positions[at, 1:D] = ustrip.(u"Å", position(system, at))
+    end
+
+    velocities = nothing
+    if !ismissing(velocity(system))
+        velocities = zeros(n_atoms, 3)
+        for at = 1:n_atoms
+            velocities[at, 1:D] = ustrip.(uVelocity, velocity(system, at))
+        end
+    end
+
+    # We don't map any extra atom properties, which are not available in ASE as this
+    # only causes a mess: ASE could do something to the atoms, but not taking
+    # care of the extra properties, thus rendering the extra properties invalid
+    # without the user noticing.
+    charges = nothing
+    magmoms = nothing
+    for key in atomkeys(system)
+        if key in (:position, :velocity, :atomic_symbol, :atomic_number, :atomic_mass)
+            continue  # Already dealt with
+        elseif key == :charge
+            charges = ustrip.(u"e_au", system[:, :charge])
+        elseif key == :magnetic_moment
+            magmoms = system[:, :magnetic_moment]
+        else
+            @warn "Skipping atomic property $key, which is not supported in ASE."
+        end
+    end
+
+    # Map extra system properties
+    info = Dict{String, Any}()
+    for (k, v) in pairs(system)
+        if k in (:bounding_box, :boundary_conditions)
+            continue
+        elseif k in (:charge, )
+            info[string(k)] = ustrip(u"e_au", v)
+        elseif v isa Quantity || (v isa AbstractArray && eltype(v) <: Quantity)
+            @warn("Unitful quantities are not yet supported in convert_ase. " *
+                  "Ignoring key $k")
+        else
+            info[string(k)] = v
+        end
+    end
+
+    ase.Atoms(; positions, numbers, masses, magmoms, charges,
+              cell, pbc, velocities, info)
+end
+
+# TODO Could have a convert_ase(Vector{AbstractSystem}) to make an ASE trajectory
+# TODO Could have a convert_ase(Vector{Vector{Unitful}}) to make an ASE cell
+# TODO Could have a way to make an ASE calculator from an InteratomicPotential object

--- a/src/ase_conversions.jl
+++ b/src/ase_conversions.jl
@@ -1,7 +1,5 @@
 import PeriodicTable
 
-export convert_ase
-
 
 # For ASE units, see https://wiki.fysik.dtu.dk/ase/ase/units.html
 # In particular note that uTime = u"Å" * sqrt(u"u" / u"eV") and thus

--- a/src/atoms_calculators.jl
+++ b/src/atoms_calculators.jl
@@ -2,6 +2,30 @@ import AtomsCalculators
 
 export ASEcalculator
 
+"""
+    ASEcalculator{T}
+
+This structure wraps python ASE calculator to AtomsCalculators
+interface compatible structure.
+
+# Example
+```julia
+using AtomsCalculators
+using ASEconvert
+using PythonCall
+
+fname = "path to eam potential file"
+EAM = pyimport("ase.calculators.eam")
+eam_cal = ASEconvert.ASEcalculator(EAM.EAM(potential=fname))
+
+atoms_ase = ase.build.bulk("Ni") * pytuple((4, 3, 2))
+atoms_ab = pyconvert(AbstractSystem, atoms_ase)
+
+AtomsCalculators.potential_energy(atoms_ab, eam_cal)
+AtomsCalculators.forces(atoms_ab, eam_cal)
+```
+
+"""
 mutable struct ASEcalculator{T}
     ase_python_calculator::T
 end

--- a/src/atoms_calculators.jl
+++ b/src/atoms_calculators.jl
@@ -1,9 +1,8 @@
 import AtomsCalculators
 
-export ASEcalculator
 
 """
-    ASEcalculator{T}
+    ASEcalculator
 
 This structure wraps python ASE calculator to AtomsCalculators
 interface compatible structure.
@@ -14,9 +13,9 @@ using AtomsCalculators
 using ASEconvert
 using PythonCall
 
-fname = "path to eam potential file"
+potential = "path to eam potential file"
 EAM = pyimport("ase.calculators.eam")
-eam_cal = ASEconvert.ASEcalculator(EAM.EAM(potential=fname))
+eam_cal = ASEconvert.ASEcalculator(EAM.EAM(potential))
 
 atoms_ase = ase.build.bulk("Ni") * pytuple((4, 3, 2))
 atoms_ab = pyconvert(AbstractSystem, atoms_ase)
@@ -26,8 +25,8 @@ AtomsCalculators.forces(atoms_ab, eam_cal)
 ```
 
 """
-mutable struct ASEcalculator{T}
-    ase_python_calculator::T
+mutable struct ASEcalculator
+    ase_python_calculator::PythonCall.Py
 end
 
 

--- a/src/atoms_calculators.jl
+++ b/src/atoms_calculators.jl
@@ -1,0 +1,45 @@
+import AtomsCalculators
+
+export ASEcalculator
+
+mutable struct ASEcalculator{T}
+    ase_python_calculator::T
+end
+
+
+AtomsCalculators.@generate_interface function AtomsCalculators.potential_energy(
+    ab_system,
+    ASEcalc::ASEcalculator;
+    kwargs...
+)
+    ase_system = convert_ase(ab_system)
+    e = ASEcalc.ase_python_calculator.get_potential_energy(ase_system)
+    return pyconvert(Float64, e) * u"eV"
+end
+
+
+AtomsCalculators.@generate_interface function AtomsCalculators.forces(
+    ab_system,
+    ASEcalc::ASEcalculator;
+    kwargs...
+)
+    ase_system = convert_ase(ab_system)
+    f = ASEcalc.ase_python_calculator.get_forces(ase_system)
+    tmp =  pyconvert(Array, f)
+    tmp2 = reinterpret(AtomsCalculators.promote_force_type(ab_system,  ASEcalc), tmp') # |> Vector
+    # This is a total hack, but better this than have complications later
+    return vec(tmp2) |> Vector
+end
+
+
+AtomsCalculators.@generate_interface function AtomsCalculators.virial(
+    ab_system,
+    ASEcalc::ASEcalculator;
+    kwargs...
+)
+    ase_system = convert_ase(ab_system)
+    tmp = ASEcalc.ase_python_calculator.get_stress(ase_system)
+    cons = ase.constraints
+    stress = cons.voigt_6_to_full_3x3_stress(tmp) * ( - ase_system.get_volume() )
+    return pyconvert(Array, stress) * u"eV"
+end

--- a/src/atoms_calculators.jl
+++ b/src/atoms_calculators.jl
@@ -37,7 +37,7 @@ AtomsCalculators.@generate_interface function AtomsCalculators.potential_energy(
 )
     ase_system = convert_ase(system)
     e = calc.ase_python_calculator.get_potential_energy(ase_system)
-    return pyconvert(Float64, e) * u"eV"
+    pyconvert(Float64, e) * u"eV"
 end
 
 
@@ -54,7 +54,7 @@ AtomsCalculators.@generate_interface function AtomsCalculators.forces(
     tmp =  pyconvert(Array, f)
     FT = AtomsCalculators.promote_force_type(system, calc)
     tmp2 = reinterpret(FT, tmp')
-    return Vector(vec(tmp2))
+    Vector(vec(tmp2))
 end
 
 
@@ -67,5 +67,5 @@ AtomsCalculators.@generate_interface function AtomsCalculators.virial(
     tmp = calc.ase_python_calculator.get_stress(ase_system)
     cons = ase.constraints
     stress = cons.voigt_6_to_full_3x3_stress(tmp) * ( - ase_system.get_volume() )
-    return pyconvert(Array, stress) * u"eV"
+    pyconvert(Array, stress) * u"eV"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,10 +133,10 @@ using UnitfulAtomic
     @testset "ASE-AtomsCalculators calculator" begin
         sys_ase = ase.build.bulk("Ar") * pytuple((5, 5, 5))
         sys_ab = pyconvert(AbstractSystem, sys_ase)
-        jl = pyimport("ase.calculators.lj")
+        lj = pyimport("ase.calculators.lj")
         ε = 125.7u"K" * u"k" |> u"eV" |> ustrip
         σ = 3.345u"Å" |> ustrip
-        lj_cal = ASEcalculator(jl.LennardJones(epsilont=ε, sigma=σ))
+        lj_cal = ASEcalculator(lj.LennardJones(epsilon=ε, sigma=σ))
         test_potential_energy(sys_ab, lj_cal)
         test_forces(sys_ab, lj_cal)
         test_virial(sys_ab, lj_cal)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,9 +134,9 @@ using UnitfulAtomic
         sys_ase = ase.build.bulk("Ar") * pytuple((5, 5, 5))
         sys_ab = pyconvert(AbstractSystem, sys_ase)
         lj = pyimport("ase.calculators.lj")
-        ε = 125.7u"K" * u"k" |> u"eV" |> ustrip
-        σ = 3.345u"Å" |> ustrip
-        lj_cal = ASEcalculator(lj.LennardJones(epsilon=ε, sigma=σ))
+        ε = ustrip(u"eV", 125.7u"K" * u"k")
+        σ = ustrip(3.345u"Å")
+        lj_cal = ASEcalculator(lj.LennardJones(;epsilon=ε, sigma=σ))
         test_potential_energy(sys_ab, lj_cal)
         test_forces(sys_ab, lj_cal)
         test_virial(sys_ab, lj_cal)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using ASEconvert
 using AtomsBase
 using AtomsBaseTesting
+using AtomsCalculators
+using AtomsCalculators.AtomsCalculatorsTesting
+using PythonCall
 using Test
 using Unitful
 using UnitfulAtomic
@@ -125,5 +128,17 @@ using UnitfulAtomic
                            ignore_atprop=[:initial_charges, :momenta, :masses,
                                           :charge, :initial_magmoms, :magnetic_moment])
         end
+    end
+
+    @testset "ASE-AtomsCalculators calculator" begin
+        sys_ase = ase.build.bulk("Ar") * pytuple((5, 5, 5))
+        sys_ab = pyconvert(AbstractSystem, sys_ase)
+        jl = pyimport("ase.calculators.lj")
+        ε = 125.7u"K" * u"k" |> u"eV" |> ustrip
+        σ = 3.345u"Å" |> ustrip
+        lj_cal = ASEcalculator(jl.LennardJones(epsilont=ε, sigma=σ))
+        test_potential_energy(sys_ab, lj_cal)
+        test_forces(sys_ab, lj_cal)
+        test_virial(sys_ab, lj_cal)
     end
 end


### PR DESCRIPTION
This PR adds adds AtomsCalculators interface support for ASE calculators.

Here is an example use

```julia
using AtomsCalculators
using ASEconvert
using PythonCall
using Unitful

sys_ase = ase.build.bulk("Ar") * pytuple((5, 5, 5))
sys_ab = pyconvert(AbstractSystem, sys_ase)
lj = pyimport("ase.calculators.lj")
ε = 125.7u"K" * u"k" |> u"eV" |> ustrip
σ = 3.345u"Å" |> ustrip
lj_cal = ASEcalculator(lj.LennardJones(epsilon=ε, sigma=σ))

AtomsCalculators.potential_energy(sys_ab, lj_cal)
AtomsCalculators.forces(sys_ab, lj_cal)
AtomsCalculators.virial(sys_ab, lj_cal)
```

@cortner